### PR TITLE
Allow URL based content-type guessing

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -2,13 +2,14 @@ import { Action, isAction } from "../types"
 import { FetchMethod } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { FormSubmission } from "./form_submission"
-import { expandURL, getAnchor, getRequestURL, Locatable, locationIsVisitable } from "../url"
+import { expandURL, getAnchor, getRequestURL, Locatable } from "../url"
 import { getAttribute } from "../../util"
 import { Visit, VisitDelegate, VisitOptions } from "./visit"
 import { PageSnapshot } from "./page_snapshot"
 
 export type NavigatorDelegate = VisitDelegate & {
   allowsVisitingLocationWithAction(location: URL, action?: Action): boolean
+  locationIsVisitable(location: URL, rootLocation: URL): boolean
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>): void
   notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL): void
 }
@@ -25,7 +26,7 @@ export class Navigator {
 
   proposeVisit(location: URL, options: Partial<VisitOptions> = {}) {
     if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
-      if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
+      if (this.delegate.locationIsVisitable(location, this.view.snapshot.rootLocation)) {
         this.delegate.visitProposedToLocation(location, options)
       } else {
         window.location.href = location.toString()

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -11,7 +11,7 @@ import { clearBusyState, dispatch, getAttribute, parseHTMLDocument, markAsBusy }
 import { FormSubmission, FormSubmissionDelegate } from "../drive/form_submission"
 import { Snapshot } from "../snapshot"
 import { ViewDelegate, ViewRenderOptions } from "../view"
-import { getAction, expandURL, urlsAreEqual, locationIsVisitable } from "../url"
+import { getAction, expandURL, urlsAreEqual } from "../url"
 import { FormSubmitObserver, FormSubmitObserverDelegate } from "../../observers/form_submit_observer"
 import { FrameView } from "./frame_view"
 import { LinkInterceptor, LinkInterceptorDelegate } from "./link_interceptor"
@@ -382,7 +382,7 @@ export class FrameController
   private formActionIsVisitable(form: HTMLFormElement, submitter?: HTMLElement) {
     const action = getAction(form, submitter)
 
-    return locationIsVisitable(expandURL(action), this.rootLocation)
+    return session.locationIsVisitable(expandURL(action), this.rootLocation)
   }
 
   private shouldInterceptNavigation(element: Element, submitter?: HTMLElement) {

--- a/src/core/frames/frame_redirector.ts
+++ b/src/core/frames/frame_redirector.ts
@@ -1,15 +1,18 @@
 import { FormSubmitObserver, FormSubmitObserverDelegate } from "../../observers/form_submit_observer"
 import { FrameElement } from "../../elements/frame_element"
 import { LinkInterceptor, LinkInterceptorDelegate } from "./link_interceptor"
-import { expandURL, getAction, locationIsVisitable } from "../url"
+import { Session } from "../session"
+import { expandURL, getAction } from "../url"
 
 export class FrameRedirector implements LinkInterceptorDelegate, FormSubmitObserverDelegate {
   readonly element: Element
+  readonly session: Session
   readonly linkInterceptor: LinkInterceptor
   readonly formSubmitObserver: FormSubmitObserver
 
-  constructor(element: Element) {
+  constructor(element: Element, session: Session) {
     this.element = element
+    this.session = session
     this.linkInterceptor = new LinkInterceptor(this, element)
     this.formSubmitObserver = new FormSubmitObserver(this, element)
   }
@@ -55,7 +58,7 @@ export class FrameRedirector implements LinkInterceptorDelegate, FormSubmitObser
     const meta = this.element.ownerDocument.querySelector<HTMLMetaElement>(`meta[name="turbo-root"]`)
     const rootLocation = expandURL(meta?.content ?? "/")
 
-    return this.shouldRedirect(form, submitter) && locationIsVisitable(action, rootLocation)
+    return this.shouldRedirect(form, submitter) && this.session.locationIsVisitable(action, rootLocation)
   }
 
   private shouldRedirect(element: Element, submitter?: HTMLElement) {

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -24,17 +24,9 @@ export function getExtension(url: URL) {
   return (getLastPathComponent(url).match(/\.[^.]*$/) || [])[0] || ""
 }
 
-export function isHTML(url: URL) {
-  return !!getExtension(url).match(/^(?:|\.(?:htm|html|xhtml|php))$/)
-}
-
 export function isPrefixedBy(baseURL: URL, url: URL) {
   const prefix = getPrefix(url)
   return baseURL.href === expandURL(prefix).href || baseURL.href.startsWith(prefix)
-}
-
-export function locationIsVisitable(location: URL, rootLocation: URL) {
-  return isPrefixedBy(location, rootLocation) && isHTML(location)
 }
 
 export function getRequestURL(url: URL) {

--- a/src/tests/fixtures/visitable.html
+++ b/src/tests/fixtures/visitable.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Visitable</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Visitable</h1>
+
+    <div>
+      <a id="link" href="/src/tests/fixtures/visitable.html">link</a>
+    </div>
+  </body>
+</html>

--- a/src/tests/functional/visitable_tests.ts
+++ b/src/tests/functional/visitable_tests.ts
@@ -1,0 +1,31 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { nextBody, pathname, visitAction } from "../helpers/page"
+
+const path = "/src/tests/fixtures/visitable.html"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(path)
+})
+
+test("test user-defined visitable URL", async ({ page }) => {
+  await page.evaluate(() => {
+    window.Turbo.session.isVisitable = (_url) => true
+  })
+
+  page.click("#link")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), path)
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test user-defined unvisitable URL", async ({ page }) => {
+  await page.evaluate(() => {
+    window.Turbo.session.isVisitable = (_url) => false
+  })
+
+  page.click("#link")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), path)
+  assert.equal(await visitAction(page), "load")
+})


### PR DESCRIPTION
Add `Session.isVisitable` method whitch is
equivalent of no longer accessible `URL.isHTML`.

This allows `Turbo.session.isVisitable` to be overriden by user and makes possible
navigation on URL's other than those with trailing slash or HTML extenion.