### PR TITLE
Resolve Frame Visit caching issue

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -303,8 +303,8 @@ export class FrameController
   viewInvalidated() {}
 
   // Frame renderer delegate
-  frameExtracted(element: FrameElement) {
-    this.previousFrameElement = element
+  willRenderFrame(currentElement: FrameElement, _newElement: FrameElement) {
+    this.previousFrameElement = currentElement.cloneNode(true)
   }
 
   visitCachedSnapshot = ({ element }: Snapshot) => {

--- a/src/core/frames/frame_renderer.ts
+++ b/src/core/frames/frame_renderer.ts
@@ -4,7 +4,7 @@ import { Render, Renderer } from "../renderer"
 import { Snapshot } from "../snapshot"
 
 export interface FrameRendererDelegate {
-  frameExtracted(element: FrameElement): void
+  willRenderFrame(currentElement: FrameElement, newElement: FrameElement): void
 }
 
 export class FrameRenderer extends Renderer<FrameElement> {
@@ -52,7 +52,7 @@ export class FrameRenderer extends Renderer<FrameElement> {
   }
 
   loadFrameElement() {
-    this.delegate.frameExtracted(this.newElement.cloneNode(true))
+    this.delegate.willRenderFrame(this.currentElement, this.newElement)
     this.renderElement(this.currentElement, this.newElement)
   }
 

--- a/src/tests/functional/frame_navigation_tests.ts
+++ b/src/tests/functional/frame_navigation_tests.ts
@@ -1,24 +1,23 @@
 import { test } from "@playwright/test"
-import { getFromLocalStorage, nextEventNamed, nextEventOnTarget, pathname } from "../helpers/page"
+import { getFromLocalStorage, nextBeat, nextEventNamed, nextEventOnTarget, pathname } from "../helpers/page"
 import { assert } from "chai"
 
-test.beforeEach(async ({ page }) => {
-  await page.goto("/src/tests/fixtures/frame_navigation.html")
-})
-
 test("test frame navigation with descendant link", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_navigation.html")
   await page.click("#inside")
 
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 })
 
 test("test frame navigation with self link", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_navigation.html")
   await page.click("#self")
 
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 })
 
 test("test frame navigation with exterior link", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_navigation.html")
   await page.click("#outside")
 
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
@@ -44,4 +43,28 @@ test("test promoted frame navigation updates the URL before rendering", async ({
 
   assert.equal(await pathname(page.url()), "/src/tests/fixtures/tabs/two.html")
   assert.equal(await page.textContent("#tab-content"), "Two")
+})
+
+test("test promoted frame navigations are cached", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/tabs.html")
+
+  await page.click("#tab-2")
+  await nextEventNamed(page, "turbo:frame-render")
+
+  assert.equal(await page.textContent("#tab-content"), "Two")
+
+  await page.click("#tab-3")
+  await nextEventNamed(page, "turbo:frame-render")
+
+  assert.equal(await page.textContent("#tab-content"), "Three")
+
+  await page.goBack()
+  await nextBeat()
+
+  assert.equal(await page.textContent("#tab-content"), "Two")
+
+  await page.goBack()
+  await nextBeat()
+
+  assert.equal(await page.textContent("#tab-content"), "One")
 })


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/643

First, rename the `FrameRendererDelegate.frameExtracted` callback method
to `willRenderFrame`, then pass along both the _current_ frame and the
_new_ frame as arguments.

Next, in the `FrameController.willRenderFrame` callback, assign the
`previousFrameElement` property (used elsewhere in the
`visitCachedSnapshot` callback) to contain the contents of the _current_
frame, instead of the _new_ frame.